### PR TITLE
Updated composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.2",
-        "cakephp/cakephp": "^4.1"
+        "cakephp/cakephp": "^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",


### PR DESCRIPTION
Plugin does not work with released 4.0 versions of CakePHP because it relys on dev versions.